### PR TITLE
Update README with v1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Supported tags and respective `Dockerfile` links
 
-- [`1.5.0`, `1.5`, `1`, `latest`, `stable` (*1.5/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/stable/Dockerfile)
-- [`1.5.0-onbuild`, `1.5-onbuild`, `1-onbuild`, `onbuild` (*1.5/onbuild/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/stable/onbuild/Dockerfile)
-- [`1.6`, `beta` (*beta/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/beta/Dockerfile)
-- [`1.6-onbuild`, `beta-onbuild` (*beta/onbuild/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/beta/onbuild/Dockerfile)
-- [`1.7`, `nightly` (*nightly/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/nightly/Dockerfile)
-- [`1.7-onbuild`, `nightly-onbuild` (*nightly/onbuild/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/nightly/onbuild/Dockerfile)
+- [`1.5.0`, `1.5` (*1.5/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/1.5/Dockerfile)
+- [`1.5.0-onbuild`, `1.5-onbuild` (*1.5/onbuild/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/1.5/onbuild/Dockerfile)
+- [`1.6.0`, `1.6`, `1`, `latest`, `stable` (*1.6/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/stable/Dockerfile)
+- [`1.6.0-onbuild`, `1.6-onbuild`, `1-onbuild`, `onbuild` (*1.6/onbuild/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/stable/onbuild/Dockerfile)
+- [`1.7`, `beta` (*beta/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/beta/Dockerfile)
+- [`1.7-onbuild`, `beta-onbuild` (*beta/onbuild/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/beta/onbuild/Dockerfile)
+- [`1.8`, `nightly` (*nightly/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/nightly/Dockerfile)
+- [`1.8-onbuild`, `nightly-onbuild` (*nightly/onbuild/Dockerfile*)](https://github.com/Scorpil/docker-rust/blob/master/nightly/onbuild/Dockerfile)


### PR DESCRIPTION
It looks like the README file does not match the images currently hosted on the Hub. This commit fixes that.
