### PR TITLE
Version 1.15 of stable Rust

### DIFF
--- a/1.14/Dockerfile
+++ b/1.14/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
        --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-ENV RUST_ARCHIVE=rust-1.15.0-x86_64-unknown-linux-gnu.tar.gz
+ENV RUST_ARCHIVE=rust-1.14.0-x86_64-unknown-linux-gnu.tar.gz
 ENV RUST_DOWNLOAD_URL=https://static.rust-lang.org/dist/$RUST_ARCHIVE
 
 RUN mkdir /rust

--- a/1.14/onbuild/Dockerfile
+++ b/1.14/onbuild/Dockerfile
@@ -1,0 +1,9 @@
+FROM scorpil/rust:1.14
+
+RUN mkdir -p /rust/app
+WORKDIR /rust/app
+
+ONBUILD COPY . /rust/app
+ONBUILD RUN cargo build --release
+
+CMD cargo run --release


### PR DESCRIPTION
This pull request adds 1.15 Rust as the new stable version.

I haven't edited the README however.