### PR TITLE
ENV persists past the build of the image.

### DIFF
--- a/templates/Dockerfile.mustache
+++ b/templates/Dockerfile.mustache
@@ -1,9 +1,7 @@
 FROM debian:jessie
 MAINTAINER Andrew Scorpil "dev@scorpil.com"
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install \
        ca-certificates \
        curl \


### PR DESCRIPTION
It shouldn't be used for DEBIAN_FRONTEND=noninteractive because future
interactive runs of the image will inherit the ENV and treat the session
as noninteractive.